### PR TITLE
Enable GitHub dependency tracking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
 import setuptools
 
-setuptools.setup()
+setuptools.setup(
+    name="docstring-to-markdown",  # to allow GitHub dependency tracking
+)


### PR DESCRIPTION
Enable GitHub dependency tracking by including the name in `setup()` call.