### PR TITLE
Google style support

### DIFF
--- a/docstring_to_markdown/__init__.py
+++ b/docstring_to_markdown/__init__.py
@@ -1,3 +1,4 @@
+from .google import google_to_markdown, looks_like_google
 from .rst import looks_like_rst, rst_to_markdown
 
 __version__ = "0.12"
@@ -10,4 +11,8 @@ class UnknownFormatError(Exception):
 def convert(docstring: str) -> str:
     if looks_like_rst(docstring):
         return rst_to_markdown(docstring)
+
+    if looks_like_google(docstring):
+        return google_to_markdown(docstring)
+
     raise UnknownFormatError()

--- a/docstring_to_markdown/google.py
+++ b/docstring_to_markdown/google.py
@@ -88,8 +88,6 @@ class Section:
     def as_markdown(self) -> str:
         return "#### {}\n\n{}\n\n".format(self.name, self.content)
 
-    def __repr__(self) -> str:
-        return "Section(name={}, content={})".format(self.name, self.content)
 
 
 class GoogleDocstring:

--- a/docstring_to_markdown/google.py
+++ b/docstring_to_markdown/google.py
@@ -102,7 +102,7 @@ class Section:
 
 class GoogleDocstring:
     def __init__(self, docstring: str) -> None:
-        self.sections: list[Section] = []
+        self.sections: List[Section] = []
         self.description: str = ""
 
         self._parse(docstring)

--- a/docstring_to_markdown/google.py
+++ b/docstring_to_markdown/google.py
@@ -2,7 +2,8 @@ import re
 from textwrap import dedent
 from typing import Dict, List, Union
 
-_GOOGLE_SECTIONS: List[str] = [
+# All possible sections in Google style docstrings
+SECTION_HEADERS: List[str] = [
     "Args",
     "Returns",
     "Raises",
@@ -10,6 +11,14 @@ _GOOGLE_SECTIONS: List[str] = [
     "Example",
     "Examples",
     "Attributes",
+    "Note",
+    "Todo",
+]
+
+# These sections will not be parsed as a list of arguments/return values/etc
+PLAIN_TEXT_SECTIONS: List[str] = [
+    "Examples",
+    "Example",
     "Note",
     "Todo",
 ]
@@ -29,6 +38,10 @@ class Section:
 
     def _parse(self, content: str) -> None:
         content = content.rstrip("\n")
+
+        if self.name in PLAIN_TEXT_SECTIONS:
+            self.content = dedent(content)
+            return
 
         parts = []
         cur_part = []
@@ -125,7 +138,7 @@ class GoogleDocstring:
 
 
 def is_section(line: str) -> bool:
-    for section in _GOOGLE_SECTIONS:
+    for section in SECTION_HEADERS:
         if re.search(r"{}:".format(section), line):
             return True
 
@@ -133,7 +146,7 @@ def is_section(line: str) -> bool:
 
 
 def looks_like_google(value: str) -> bool:
-    for section in _GOOGLE_SECTIONS:
+    for section in SECTION_HEADERS:
         if re.search(r"{}:\n".format(section), value):
             return True
 

--- a/docstring_to_markdown/google.py
+++ b/docstring_to_markdown/google.py
@@ -1,0 +1,137 @@
+import re
+from typing import Dict, List, Union
+
+_GOOGLE_SECTIONS: List[str] = [
+    "Args",
+    "Returns",
+    "Raises",
+    "Yields",
+    "Example",
+    "Examples",
+    "Attributes",
+    "Note",
+]
+
+ESCAPE_RULES = {
+    # Avoid Markdown in magic methods or filenames like __init__.py
+    r"__(?P<text>\S+)__": r"\_\_\g<text>\_\_",
+}
+
+
+class Section:
+    def __init__(self, name: str, content: str) -> None:
+        self.name = name
+        self.content = ""
+
+        self._parse(content)
+
+    def _parse(self, content: str) -> None:
+        content = content.rstrip("\n")
+
+        parts = []
+        cur_part = []
+
+        for line in content.split("\n"):
+            line = line.replace("    ", "", 1)
+
+            if line.startswith(" "):
+                # Continuation from a multiline description
+                cur_part.append(line)
+                continue
+
+            if cur_part:
+                # Leaving multiline description
+                parts.append(cur_part)
+                cur_part = [line]
+            else:
+                # Entering new description part
+                cur_part.append(line)
+
+        # Last part
+        parts.append(cur_part)
+
+        # Format section
+        for part in parts:
+            self.content += "- {}\n".format(part[0])
+
+            for line in part[1:]:
+                self.content += "  {}\n".format(line)
+
+        self.content = self.content.rstrip("\n")
+
+    def as_markdown(self) -> str:
+        return "# {}\n\n{}\n\n".format(self.name, self.content)
+
+    def __repr__(self) -> str:
+        return "Section(name={}, content={})".format(self.name, self.content)
+
+
+class GoogleDocstring:
+    def __init__(self, docstring: str) -> None:
+        self.sections: list[Section] = []
+        self.description: str = ""
+
+        self._parse(docstring)
+
+    def _parse(self, docstring: str) -> None:
+        self.sections = []
+        self.description = ""
+
+        buf = ""
+        cur_section = ""
+
+        for line in docstring.split("\n"):
+            if is_section(line):
+                # Entering new section
+                if cur_section:
+                    # Leaving previous section, save it and reset buffer
+                    self.sections.append(Section(cur_section, buf))
+                    buf = ""
+
+                # Remember currently parsed section
+                cur_section = line.rstrip(":")
+                continue
+
+            # Parse section content
+            if cur_section:
+                buf += line + "\n"
+            else:
+                # Before setting cur_section, we're parsing the function description
+                self.description += line + "\n"
+
+        # Last section
+        self.sections.append(Section(cur_section, buf))
+
+    def as_markdown(self) -> str:
+        text = self.description
+
+        for section in self.sections:
+            text += section.as_markdown()
+
+        return text.rstrip("\n") + "\n"  # Only keep one last newline
+
+
+def is_section(line: str) -> bool:
+    for section in _GOOGLE_SECTIONS:
+        if re.search(r"{}:".format(section), line):
+            return True
+
+    return False
+
+
+def looks_like_google(value: str) -> bool:
+    for section in _GOOGLE_SECTIONS:
+        if re.search(r"{}:\n".format(section), value):
+            return True
+
+    return False
+
+
+def google_to_markdown(text: str, extract_signature: bool = True) -> str:
+    # Escape parts we don't want to render
+    for pattern, replacement in ESCAPE_RULES.items():
+        text = re.sub(pattern, replacement, text)
+
+    docstring = GoogleDocstring(text)
+
+    return docstring.as_markdown()

--- a/docstring_to_markdown/google.py
+++ b/docstring_to_markdown/google.py
@@ -52,7 +52,15 @@ class Section:
 
         # Format section
         for part in parts:
-            self.content += "- {}\n".format(part[0])
+            if ":" in part[0]:
+                spl = part[0].split(":")
+
+                arg = spl[0]
+                description = ":".join(spl[1:])
+
+                self.content += "- `{}`: {}\n".format(arg, description)
+            else:
+                self.content += "- {}\n".format(part[0])
 
             for line in part[1:]:
                 self.content += "  {}\n".format(line)
@@ -60,7 +68,7 @@ class Section:
         self.content = self.content.rstrip("\n")
 
     def as_markdown(self) -> str:
-        return "# {}\n\n{}\n\n".format(self.name, self.content)
+        return "#### {}\n\n{}\n\n".format(self.name, self.content)
 
     def __repr__(self) -> str:
         return "Section(name={}, content={})".format(self.name, self.content)

--- a/docstring_to_markdown/google.py
+++ b/docstring_to_markdown/google.py
@@ -1,4 +1,5 @@
 import re
+from textwrap import dedent
 from typing import Dict, List, Union
 
 _GOOGLE_SECTIONS: List[str] = [
@@ -10,6 +11,7 @@ _GOOGLE_SECTIONS: List[str] = [
     "Examples",
     "Attributes",
     "Note",
+    "Todo",
 ]
 
 ESCAPE_RULES = {
@@ -52,18 +54,21 @@ class Section:
 
         # Format section
         for part in parts:
+            indentation = ""
+
             if ":" in part[0]:
                 spl = part[0].split(":")
 
                 arg = spl[0]
-                description = ":".join(spl[1:])
+                description = ":".join(spl[1:]).lstrip()
+                indentation = (len(arg) + 6) * " "
 
                 self.content += "- `{}`: {}\n".format(arg, description)
             else:
                 self.content += "- {}\n".format(part[0])
 
             for line in part[1:]:
-                self.content += "  {}\n".format(line)
+                self.content += "{}{}\n".format(indentation, line.lstrip())
 
         self.content = self.content.rstrip("\n")
 

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -75,6 +75,9 @@ Args:
              spanning over several lines
         also with broken indentation
     b (str): Second arg
+    c (str):
+        On the next line
+        And also multiple lines
 """
 
 MULTILINE_ARG_DESCRIPTION_MD = """Example.
@@ -85,6 +88,8 @@ MULTILINE_ARG_DESCRIPTION_MD = """Example.
              spanning over several lines
              also with broken indentation
 - `b (str)`: Second arg
+- `c (str)`: On the next line
+             And also multiple lines
 """
 
 GOOGLE_CASES = {

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -1,6 +1,10 @@
+import pytest
+
 from docstring_to_markdown.google import google_to_markdown, looks_like_google
 
 BASIC_EXAMPLE = """Do **something**.
+
+Some more detailed description.
 
 Args:
     a: some arg
@@ -12,19 +16,104 @@ Returns:
 
 BASIC_EXAMPLE_MD = """Do **something**.
 
-# Args
+Some more detailed description.
 
-- a: some arg
-- b: some arg
+#### Args
 
-# Returns
+- `a`: some arg
+- `b`: some arg
+
+#### Returns
 
 - Same *stuff*
 """
 
+ESCAPE_MAGIC_METHOD = """Example.
 
-def test_looks_like_google_recognises_google():
-    assert looks_like_google(BASIC_EXAMPLE)
+Args:
+    a: see __init__.py
+"""
+
+ESCAPE_MAGIC_METHOD_MD = """Example.
+
+#### Args
+
+- `a`: see \\_\\_init\\_\\_.py
+"""
+
+PLAIN_SECTION = """Example.
+
+Args:
+    a: some arg
+
+Note:
+    Do not use this.
+
+Example:
+    Do it like this.
+"""
+
+PLAIN_SECTION_MD = """Example.
+
+#### Args
+
+- `a`: some arg
+
+#### Note
+
+Do not use this.
+
+#### Example
+
+Do it like this.
+"""
+
+MULTILINE_ARG_DESCRIPTION = """Example.
+
+Args:
+    a (str): This is a long description
+             spanning over several lines
+        also with broken indentation
+    b (str): Second arg
+"""
+
+MULTILINE_ARG_DESCRIPTION_MD = """Example.
+
+#### Args
+
+- `a (str)`: This is a long description
+             spanning over several lines
+             also with broken indentation
+- `b (str)`: Second arg
+"""
+
+GOOGLE_CASES = {
+    "basic example": {
+        "google": BASIC_EXAMPLE,
+        "md": BASIC_EXAMPLE_MD,
+    },
+    "escape magic method": {
+        "google": ESCAPE_MAGIC_METHOD,
+        "md": ESCAPE_MAGIC_METHOD_MD,
+    },
+    "plain section": {
+        "google": PLAIN_SECTION,
+        "md": PLAIN_SECTION_MD,
+    },
+    "multiline arg description": {
+        "google": MULTILINE_ARG_DESCRIPTION,
+        "md": MULTILINE_ARG_DESCRIPTION_MD,
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "google",
+    [case["google"] for case in GOOGLE_CASES.values()],
+    ids=GOOGLE_CASES.keys(),
+)
+def test_looks_like_google_recognises_google(google):
+    assert looks_like_google(google)
 
 
 def test_looks_like_google_ignores_plain_text():
@@ -32,5 +121,10 @@ def test_looks_like_google_ignores_plain_text():
     assert not looks_like_google("See Also\n--------\n")
 
 
-def test_google_to_markdown():
-    assert google_to_markdown(BASIC_EXAMPLE) == BASIC_EXAMPLE_MD
+@pytest.mark.parametrize(
+    "google,markdown",
+    [[case["google"], case["md"]] for case in GOOGLE_CASES.values()],
+    ids=GOOGLE_CASES.keys(),
+)
+def test_google_to_markdown(google, markdown):
+    assert google_to_markdown(google) == markdown

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -1,0 +1,36 @@
+from docstring_to_markdown.google import google_to_markdown, looks_like_google
+
+BASIC_EXAMPLE = """Do **something**.
+
+Args:
+    a: some arg
+    b: some arg
+
+Returns:
+    Same *stuff*
+"""
+
+BASIC_EXAMPLE_MD = """Do **something**.
+
+# Args
+
+- a: some arg
+- b: some arg
+
+# Returns
+
+- Same *stuff*
+"""
+
+
+def test_looks_like_google_recognises_google():
+    assert looks_like_google(BASIC_EXAMPLE)
+
+
+def test_looks_like_google_ignores_plain_text():
+    assert not looks_like_google("This is plain text")
+    assert not looks_like_google("See Also\n--------\n")
+
+
+def test_google_to_markdown():
+    assert google_to_markdown(BASIC_EXAMPLE) == BASIC_EXAMPLE_MD


### PR DESCRIPTION
This PR adds basic support for google style docstrings.

Resources used:

- https://google.github.io/styleguide/pyguide.html#s3.8-comments-and-docstrings
- https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html

### Supported features

- [x] Function description, short and long
- [x] Arguments parsed into a list
- [x] Return values, raised exceptions, yields for generators
- [x] Example, note, todo blocks
- [x] Multiline argument descriptions
- [x] Indented argument descriptions
- [x] Inline markdown
- [x] Underscore escaping (`__init__.py`, `__str__`, ...)
- [ ] RST-like links
  - The [official Google guide](https://google.github.io/styleguide/pyguide.html#s3.8-comments-and-docstrings) doesn't mention these, but [this guide](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) does
- [ ] Literal blocks
  - Same as with RST-like links

### Example

Screenshot from Sublime Text 4 before this change:

![before](https://github.com/python-lsp/docstring-to-markdown/assets/44530786/7e93473f-180d-4739-a17b-a542f035a62d)

and after with the support enabled:

![after](https://github.com/python-lsp/docstring-to-markdown/assets/44530786/c61a0e13-1c8e-4240-8b01-3c08d10443b3)

This is the code used for this example:

```py
def something(a: str) -> str:
    """Do **something**. But not __init__.py.

    Some longer description here, that's allowed.
    See ``Args`` in `self`.

    Args:
        a (str): some arg with type
                 with multiline
                 comment
        b:
            some arg without type
        *args: Yayaya
        **kwargs: dadada

    Returns:
        str: the same *stuff*

    Raises:
        ValueError: if something bad happens
                    but y'know
        KeyError: if something else equally bad happens

    Examples:
        Use it like this.

    Note:
        Do not use this function. Or https://github.com.

    Todo:
        * Not sure
        * Test
    """
    return a
```