### PR TITLE
Fix multi-line links and incorrect dunder escapes in code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
-        include:
-          - os: ubuntu-20.04
-            python-version: 3.6
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 On the fly conversion of Python docstrings to markdown
 
-- Python 3.6+
+- Python 3.6+ (tested on 3.7 up to 3.11)
 - can recognise reStructuredText and convert multiple of its features to Markdown
 - since v0.13 includes initial support for Google-formatted docstrings
 

--- a/docstring_to_markdown/__init__.py
+++ b/docstring_to_markdown/__init__.py
@@ -3,7 +3,7 @@ from .google import google_to_markdown, looks_like_google
 from .plain import looks_like_plain_text, plain_text_to_markdown
 from .rst import looks_like_rst, rst_to_markdown
 
-__version__ = "0.14"
+__version__ = "0.15"
 
 
 class UnknownFormatError(Exception):

--- a/docstring_to_markdown/rst.py
+++ b/docstring_to_markdown/rst.py
@@ -1,13 +1,13 @@
 from abc import ABC, abstractmethod
 from enum import IntEnum, auto
 from types import SimpleNamespace
-from typing import Union, List, Dict
+from typing import Callable, Match, Union, List, Dict
 import re
 
 
 class Directive:
     def __init__(
-        self, pattern: str, replacement: str,
+        self, pattern: str, replacement: Union[str, Callable[[Match], str]],
         name: Union[str, None] = None,
         flags: int = 0
     ):
@@ -249,7 +249,7 @@ RST_DIRECTIVES: List[Directive] = [
     ),
     Directive(
         pattern=r'`(?P<label>[^<`]+?)(\n?)<(?P<url>[^>`]+)>`_+',
-        replacement=r'[\g<label>](\g<url>)'
+        replacement=lambda m: '[' + m.group('label') + '](' + re.sub(r"\s+", "", m.group('url')) + ')'
     ),
     Directive(
         pattern=r':mod:`(?P<label>[^`]+)`',
@@ -316,7 +316,7 @@ SECTION_DIRECTIVES: Dict[str, List[Directive]] = {
 
 ESCAPING_RULES: List[Directive] = [
     Directive(
-        pattern=r'__(?P<text>\S+)__',
+        pattern=r'(?<!`)__(?P<text>\S+)__(?!`)',
         replacement=r'\_\_\g<text>\_\_'
     )
 ]

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -78,6 +78,17 @@ RST_LINK_EXAMPLE_MARKDOWN = (
     "[this link](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)."
 )
 
+RST_LINK_MULTILINE_EXAMPLE = """
+See
+`strftime documentation
+<https://docs.python.org/3/library/datetime.html
+#strftime-and-strptime-behavior>`_ for more.
+"""
+RST_LINK_MULTILINE_MARKDOWN = """
+See
+[strftime documentation](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior) for more.
+"""
+
 RST_REF_EXAMPLE = """See :ref:`here <timeseries.offset_aliases>` for a list of frequency aliases."""
 RST_REF_MARKDOWN = """See here: `timeseries.offset_aliases` for a list of frequency aliases."""
 
@@ -686,6 +697,10 @@ RST_CASES = {
         'rst': RST_LINK_EXAMPLE,
         'md': RST_LINK_EXAMPLE_MARKDOWN
     },
+    'converts multi-line links': {
+        'rst': RST_LINK_MULTILINE_EXAMPLE,
+        'md': RST_LINK_MULTILINE_MARKDOWN
+    },
     'changes highlight': {
         'rst': RST_HIGHLIGHTED_BLOCK,
         'md': RST_HIGHLIGHTED_BLOCK_MARKDOWN
@@ -763,6 +778,10 @@ RST_CASES = {
         # https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-markup-recognition-rules
         'rst': '__init__',
         'md': r'\_\_init\_\_'
+    },
+    'does not escape dunders in code': {
+        'rst': '`__init__`',
+        'md': '`__init__`'
     },
     'converts bibliographic references': {
         'rst': REFERENCES,


### PR DESCRIPTION
Small fix to improve rendering of links where URL part was spread across multiple lines, and prevent spurious escape of dunders when wrapped in code delimeters.